### PR TITLE
chore: bump pnpm via corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,5 @@
     "playwright": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
+  "packageManager": "pnpm@11.15.1+sha512.81350b07e53c9538a02f1f2303b4290fa2d7be04e56e2a970c4cc4b417dc761de196edabd49d55c7dc9580db81007c44143e4e3d7e462b3000d23c255122d065"
 }


### PR DESCRIPTION
Automated update of the pnpm toolchain pin using Corepack.

Command run:
- corepack use pnpm@11.15.1

Version metadata:
- Published at: 2026-07-19T22:30:38.100Z
- Cooldown: at least 24 hours old
- Channel: stable only (no prereleases)