### PR TITLE
Use S.is for sury string benchmarks, tighten codec test

### DIFF
--- a/schemas/libraries/sury/benchmarks.ts
+++ b/schemas/libraries/sury/benchmarks.ts
@@ -12,8 +12,7 @@ const createStringBenchmark = (
   snippet: string,
 ): StringBenchmarkConfig => ({
   create() {
-    const parser = S.parser(schema);
-    return (testString) => S.safe(() => parser(testString)).success;
+    return (testString) => S.is(schema, testString);
   },
   snippet,
 });

--- a/schemas/test/libraries.node.test.ts
+++ b/schemas/test/libraries.node.test.ts
@@ -95,8 +95,7 @@ describe.each(Object.entries(libraries))("%s", async (_name, getConfig) => {
         const { encode, decode } = config;
         const bigint = 1234567890123456789n;
         const encoded = await encode.run(bigint);
-        // we don't test for format here - usually it'll be ISO, but no need to require it
-        expect(encoded).toBeTypeOf("string");
+        expect(encoded).toBe("1234567890123456789");
         const decoded = await decode.run(encoded);
         // check the bigint is the same
         expect(decoded).toEqual(bigint);


### PR DESCRIPTION
Two small changes to the benchmark definitions.

**Use `S.is` for sury's string format benchmarks.** These measure validation only, but sury was building a parser and wrapping it in `S.safe` to get a boolean, charging it for parsing plus exception handling:

```ts
const parser = S.parser(schema);
return (testString) => S.safe(() => parser(testString)).success;
// now:
return (testString) => S.is(schema, testString);
```

`S.is` is sury's validation-only API, already used for the `validation` benchmark in the same file. This matches how every other library with a boolean-returning API is benchmarked here — valibot `v.is`, shapeshift `schema.is`, arktype `.allows`, typebox `Schema.Check`, yup `isValidSync`, ajv the compiled validator. Ones still going through a result object (zod, paseri, joi) do so only because they have no boolean-only entry point. Affects `date-time`, `email`, `url`, `uuid`; those numbers will change on re-run.

**Assert the exact encoded string in the codec test.** The codec benchmarks encode a bigint, so the result is deterministic — `expect(encoded).toBeTypeOf("string")` was left over from when Dates were coerced.
