### PR TITLE
chore: bump pnpm via corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "playwright": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@11.17.0+sha512.cca3cea332ad254bb84145f966d19f4879615210346fc92c79a047f23a0d7b3cca3c3792f0076ba1f1831d277efbcf0a9119b31a9a60eca7fb3d6231f331ef72"
+  "packageManager": "pnpm@11.18.0+sha512.33d83c77da82f49fba836925c6f1b841181ec3132b670639bd012f7075f5c7cf634c5f870147c19aae7478fac01df09d8892e880454896edd23ee9b33757563c"
 }


### PR DESCRIPTION
Automated update of the pnpm toolchain pin using Corepack.

Command run:
- corepack use pnpm@11.18.0

Version metadata:
- Published at: 2026-07-29T07:50:16.898Z
- Cooldown: at least 24 hours old
- Channel: stable only (no prereleases)