### PR TITLE
chore: bump pnpm via corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,5 @@
     "playwright": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@11.18.0+sha512.33d83c77da82f49fba836925c6f1b841181ec3132b670639bd012f7075f5c7cf634c5f870147c19aae7478fac01df09d8892e880454896edd23ee9b33757563c"
+  "packageManager": "pnpm@11.19.0+sha512.7881f3ed590d472c4a955e2b88b2121791116066dcc88cbca3849ec9b60f1bbaa6d2ccb221fa91da4e1c65bef2bcbe379365aea7ac539c7bf86dedc3a1b22dce"
 }


### PR DESCRIPTION
Automated update of the pnpm toolchain pin using Corepack.

Command run:
- corepack use pnpm@11.19.0

Version metadata:
- Published at: 2026-07-31T09:09:14.330Z
- Cooldown: at least 24 hours old
- Channel: stable only (no prereleases)