### PR TITLE
chore: bump pnpm via corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,5 +37,5 @@
     "playwright": "catalog:",
     "typescript": "catalog:"
   },
-  "packageManager": "pnpm@11.21.0+sha512.521705bce689924eac72f5a3587122f362689ef6571e55ba80076fd637c11132ecffada26fad4ea79c485bfddbfd3d5a2a5b05805a77e893de71ec8a6cca3bb1"
+  "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621"
 }


### PR DESCRIPTION
Automated update of the pnpm toolchain pin using Corepack.

Command run:
- corepack use pnpm@11.22.0

Version metadata:
- Published at: 2026-08-15T17:15:57.450Z
- Cooldown: at least 24 hours old
- Channel: stable only (no prereleases)