### PR TITLE
chore: bump JSON Schema test-suite SHA

### DIFF
--- a/json-schema-tests/constants/sha.gen.ts
+++ b/json-schema-tests/constants/sha.gen.ts
@@ -1,3 +1,3 @@
 // Pinned upstream revision for json-schema-org/json-schema-test-suite.
 // Update this with \`pnpm json-schema-tests:bump\`. Optionally provide a commit SHA to set a specific commit, e.g. \`pnpm json-schema-tests:bump -c <sha>\`.
-export default "15fe552d6cf76e29cc8165306fb6a72503fd360b"; // test(uri-template): add literal apostrophe case (#1058)
+export default "6648e8194c69697b2e1a15fe76a06a480b183a51"; // test(uri-reference): reject a colon in the first segment of a relative reference (#1079)


### PR DESCRIPTION
Automated weekly update of the pinned `json-schema-org/json-schema-test-suite` commit.

New pinned commit:
- SHA: 6648e8194c69697b2e1a15fe76a06a480b183a51
- Message: test(uri-reference): reject a colon in the first segment of a relative reference (#1079)

Command run:
- `pnpm json-schema-tests:bump`