### PR TITLE
chore: bump JSON Schema test-suite SHA

### DIFF
--- a/json-schema-tests/constants/sha.gen.ts
+++ b/json-schema-tests/constants/sha.gen.ts
@@ -1,3 +1,3 @@
 // Pinned upstream revision for json-schema-org/json-schema-test-suite.
 // Update this with \`pnpm json-schema-tests:bump\`. Optionally provide a commit SHA to set a specific commit, e.g. \`pnpm json-schema-tests:bump -c <sha>\`.
-export default "6648e8194c69697b2e1a15fe76a06a480b183a51"; // test(uri-reference): reject a colon in the first segment of a relative reference (#1079)
+export default "b01af8c8d50244a2eb4dd3e01073e24823aa8691"; // test(iri-reference): add a trailing newline as invalid (#1144)


### PR DESCRIPTION
Automated weekly update of the pinned `json-schema-org/json-schema-test-suite` commit.

New pinned commit:
- SHA: b01af8c8d50244a2eb4dd3e01073e24823aa8691
- Message: test(iri-reference): add a trailing newline as invalid (#1144)

Command run:
- `pnpm json-schema-tests:bump`