### PR TITLE
zod: use z.validate for string format benchmarks

### DIFF
--- a/schemas/libraries/zod/benchmarks.ts
+++ b/schemas/libraries/zod/benchmarks.ts
@@ -14,7 +14,7 @@ const createStringBenchmark = (
 ): StringBenchmarkConfig => ({
   create() {
     const schema = factory();
-    return (testString) => schema.safeParse(testString).success;
+    return (testString) => z.validate(schema, testString);
   },
   snippet,
 });

--- a/schemas/libraries/zod/mini/benchmarks.ts
+++ b/schemas/libraries/zod/mini/benchmarks.ts
@@ -13,7 +13,7 @@ const createStringBenchmark = (
 ): StringBenchmarkConfig => ({
   create() {
     const schema = factory();
-    return (testString) => schema.safeParse(testString).success;
+    return (testString) => z.validate(schema, testString);
   },
   snippet,
 });


### PR DESCRIPTION
The zod and zod/mini string format benchmarks call `schema.safeParse(testString).success`, which constructs a full `ZodError` on every invalid string. The other adapters in this category use their boolean check APIs (`v.is`, `S.is`, `.allows`, `Value.Check`), which skip error materialization.

This switches both adapters to `z.validate(schema, testString)` — the same API the validation benchmarks adopted in #263. On my machine the invalid-string case for `z.email()` goes from ~1100 ns to ~270 ns; the valid case is unchanged.

Ran the schemas test suite; the zod, zod/mini, zod/v3 and zod-compiler blocks pass (1622 tests).
